### PR TITLE
Add macos-13 to the known labels

### DIFF
--- a/github/job.go
+++ b/github/job.go
@@ -204,6 +204,9 @@ func IsMacRunner(label string) bool {
 	if label == "macos-latest" {
 		return true
 	}
+	if label == "macos-13" {
+		return true
+	}
 	if label == "macos-12" {
 		return true
 	}


### PR DESCRIPTION
Otherwise the usage of macos-13 runners would be counted as selfhosted